### PR TITLE
README: document new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,78 @@ That's it! You can use `go get` to get the package from your custom domain.
 ```
 $ go get customdomain.com/portmidi
 ```
+
+### Running in other environments
+
+You can also deploy this as an App Engine Flexible app by changing the
+`app.yaml` file:
+
+```
+runtime: go
+env: flex
+```
+
+This project is a normal Go HTTP server, so you can also incorporate the
+handler into larger Go servers.
+
+## Configuration File
+
+```
+host: example.com
+paths:
+  /foo:
+    repo: https://github.com/example/foo
+    display: "https://github.com/example/foo https://github.com/example/foo/tree/master{/dir} https://github.com/example/foo/blob/master{/dir}/{file}#L{line}"
+    vcs: git
+```
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Required</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><code>host</code></th>
+      <td>optional</td>
+      <td>Host name to use in meta tags.  If omitted, uses the App Engine default version host or the Host header on non-App Engine Standard environments.  You can use this option to fix the host when using this service behind a reverse proxy or a <a href="https://cloud.google.com/appengine/docs/standard/go/how-requests-are-routed#routing_with_a_dispatch_file">custom dispatch file</a>.</td>
+    </tr>
+    <tr>
+      <th scope="row"><code>paths</code></th>
+      <td>required</td>
+      <td>Map of paths to path configurations.  Each key is a path that will point to the root of a repository hosted elsewhere.  The fields are documented in the Path Configuration section below.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Path Configuration
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Required</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row"><code>display</code></th>
+      <td>optional</td>
+      <td>The last three fields of the <a href="https://github.com/golang/gddo/wiki/Source-Code-Links"><code>go-source</code> meta tag</a>.  If omitted, it is inferred from the code hosting service if possible.</td>
+    </tr>
+    <tr>
+      <th scope="row"><code>repo</code></th>
+      <td>required</td>
+      <td>Root URL of the repository as it would appear in <a href="https://golang.org/cmd/go/#hdr-Remote_import_paths"><code>go-import</code> meta tag</a>.</td>
+    </tr>
+    <tr>
+      <th scope="row"><code>vcs</code></th>
+      <td>required if ambiguous</td>
+      <td>If the version control system cannot be inferred (e.g. for Bitbucket or a custom domain), then this specifies the version control system as it would appear in <a href="https://golang.org/cmd/go/#hdr-Remote_import_paths"><code>go-import</code> meta tag</a>.  This can be one of <code>git</code>, <code>hg</code>, <code>svn</code>, or <code>bzr</code>.</td>
+    </tr>
+  </tbody>
+</table>

--- a/main.go
+++ b/main.go
@@ -24,10 +24,16 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 2 {
-		log.Fatal("usage: govanityurls CONFIG")
+	var configPath string
+	switch len(os.Args) {
+	case 1:
+		configPath = "vanity.yaml"
+	case 2:
+		configPath = os.Args[1]
+	default:
+		log.Fatal("usage: govanityurls [CONFIG]")
 	}
-	vanity, err := ioutil.ReadFile(os.Args[1])
+	vanity, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Add reference section for configuration file and note that the server can run in other compute environments.

Tweaked main.go slightly to default to using vanity.yaml for App Engine Flex.