### PR TITLE
handler: use longest prefix, shortest subpath matches to query if no route is found

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -194,5 +194,25 @@ func (pset pathConfigSet) find(path string) (pc *pathConfig, subpath string) {
 	if i > 0 && strings.HasPrefix(path, pset[i-1].path+"/") {
 		return &pset[i-1], path[len(pset[i-1].path)+1:]
 	}
-	return nil, ""
+
+	// Otherwise now look for the shortest prefix pathConfig
+	// For example:
+	//  * Given pathConfigs {"/y", "/example/helloworld", "/"}
+	//  * Query "/x" should return "/"
+	//  * Query "/example/helloworld/foo" should return "/example/helloworld"
+	shortestWeight := len(path)
+	var shortestPrefixConfig *pathConfig
+	for i, ps := range pset {
+		if len(ps.path) >= len(path) {
+			// We previously didn't find the path by search, so any
+			// route with equal or greater length is NOT a match.
+			continue
+		}
+		rest := strings.TrimPrefix(path, ps.path)
+		if len(rest) < shortestWeight {
+			shortestWeight = len(rest)
+			shortestPrefixConfig = &pset[i]
+		}
+	}
+	return shortestPrefixConfig, ""
 }

--- a/handler.go
+++ b/handler.go
@@ -203,7 +203,12 @@ func (pset pathConfigSet) find(path string) (pc *pathConfig, subpath string) {
 	//  * query "/x" returns "/" with a subpath of "x"
 	lenShortestSubpath := len(path)
 	var bestMatchConfig *pathConfig
-	for i, ps := range pset {
+
+	// After binary search with the >= lexicographic comparison,
+	// nothing greater than i will be a prefix of path.
+	max := i
+	for i := 0; i < max; i++ {
+		ps := pset[i]
 		if len(ps.path) >= len(path) {
 			// We previously didn't find the path by search, so any
 			// route with equal or greater length is NOT a match.

--- a/handler.go
+++ b/handler.go
@@ -197,11 +197,11 @@ func (pset pathConfigSet) find(path string) (pc *pathConfig, subpath string) {
 		return &pset[i-1], path[len(pset[i-1].path)+1:]
 	}
 
-	// Slow path, now looking for the closest match that's also a prefix i.e.
+	// Slow path, now looking for the longest prefix/shortest subpath i.e.
 	// e.g. given pset ["/", "/abc/", "/abc/def/", "/xyz"/]
-	//  * query "/abc/foo" returns "/abc/"
-	//  * query "/x" returns "/"
-	shortestWeight := len(path)
+	//  * query "/abc/foo" returns "/abc/" with a subpath of "foo"
+	//  * query "/x" returns "/" with a subpath of "x"
+	lenShortestSubpath := len(path)
 	var bestMatchConfig *pathConfig
 	for i, ps := range pset {
 		if len(ps.path) >= len(path) {
@@ -209,11 +209,12 @@ func (pset pathConfigSet) find(path string) (pc *pathConfig, subpath string) {
 			// route with equal or greater length is NOT a match.
 			continue
 		}
-		rest := strings.TrimPrefix(path, ps.path)
-		if len(rest) < shortestWeight {
-			shortestWeight = len(rest)
+		sSubpath := strings.TrimPrefix(path, ps.path)
+		if len(sSubpath) < lenShortestSubpath {
+			subpath = sSubpath
+			lenShortestSubpath = len(sSubpath)
 			bestMatchConfig = &pset[i]
 		}
 	}
-	return bestMatchConfig, ""
+	return bestMatchConfig, subpath
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -207,6 +207,43 @@ func TestPathConfigSetFind(t *testing.T) {
 			want:    "/portmidi",
 			subpath: "foo",
 		},
+		{
+			paths:   []string{"/example/helloworld", "/", "/y", "/foo"},
+			query:   "/x",
+			want:    "/",
+			subpath: "",
+		},
+		{
+			paths:   []string{"/example/helloworld", "/", "/y", "/foo"},
+			query:   "/",
+			want:    "/",
+			subpath: "",
+		},
+		{
+			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
+			query: "/example",
+			want:  "/",
+		},
+		{
+			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
+			query: "/example/foo",
+			want:  "/",
+		},
+		{
+			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
+			query: "/y",
+			want:  "/y",
+		},
+		{
+			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
+			query: "/x/y/",
+			want:  "/",
+		},
+		{
+			paths: []string{"/example/helloworld", "/y", "/foo"},
+			query: "/x",
+			want:  "",
+		},
 	}
 	emptyToNil := func(s string) string {
 		if s == "" {

--- a/handler_test.go
+++ b/handler_test.go
@@ -211,7 +211,7 @@ func TestPathConfigSetFind(t *testing.T) {
 			paths:   []string{"/example/helloworld", "/", "/y", "/foo"},
 			query:   "/x",
 			want:    "/",
-			subpath: "",
+			subpath: "x",
 		},
 		{
 			paths:   []string{"/example/helloworld", "/", "/y", "/foo"},
@@ -220,14 +220,16 @@ func TestPathConfigSetFind(t *testing.T) {
 			subpath: "",
 		},
 		{
-			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
-			query: "/example",
-			want:  "/",
+			paths:   []string{"/example/helloworld", "/", "/y", "/foo"},
+			query:   "/example",
+			want:    "/",
+			subpath: "example",
 		},
 		{
-			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
-			query: "/example/foo",
-			want:  "/",
+			paths:   []string{"/example/helloworld", "/", "/y", "/foo"},
+			query:   "/example/foo",
+			want:    "/",
+			subpath: "example/foo",
 		},
 		{
 			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
@@ -238,6 +240,7 @@ func TestPathConfigSetFind(t *testing.T) {
 			paths: []string{"/example/helloworld", "/", "/y", "/foo"},
 			query: "/x/y/",
 			want:  "/",
+			subpath:  "x/y/",
 		},
 		{
 			paths: []string{"/example/helloworld", "/y", "/foo"},


### PR DESCRIPTION
Fixes #18

If any pathConfig is the longest prefix of a query,
find and return it.

For example:
* PathConfigs: {"/example/helloworld", "/example", "/", "/x"}

Query|Result
---|---
"/example/helloworld/foo"|"/example/helloworld"
"/foo"|"/"
"/y"|"/"
"foo"|""
"/y/x"|"/"
"/x/y"|"/x"