### PR TITLE
add a -listen flag for the HTTP server address

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,19 +17,24 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 )
 
 func main() {
+	var (
+		flListenAddr = flag.String("listen", ":8080", "HTTP server address (defaults to :8080)")
+	)
+	flag.Parse()
+
 	var configPath string
-	switch len(os.Args) {
-	case 1:
+	switch len(flag.Args()) {
+	case 0:
 		configPath = "vanity.yaml"
-	case 2:
-		configPath = os.Args[1]
+	case 1:
+		configPath = flag.Args()[0]
 	default:
 		log.Fatal("usage: govanityurls [CONFIG]")
 	}
@@ -42,7 +47,7 @@ func main() {
 		log.Fatal(err)
 	}
 	http.Handle("/", h)
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	if err := http.ListenAndServe(*flListenAddr, nil); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Since I deploy the binary to my server directly using systemd I need to restrict the listen address. Might be useful for others too.