### PR TITLE
Fix configs which use a root path, and subpaths

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -63,7 +63,7 @@ func newHandler(config []byte) (*handler, error) {
 	h.cacheControl = fmt.Sprintf("public, max-age=%d", cacheAge)
 	for path, e := range parsed.Paths {
 		pc := pathConfig{
-			path:    strings.TrimSuffix(path, "/"),
+			path:    path,
 			repo:    e.Repo,
 			display: e.Display,
 			vcs:     e.VCS,
@@ -113,7 +113,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Display string
 		VCS     string
 	}{
-		Import:  h.Host(r) + pc.path,
+		Import:  h.Host(r) + strings.TrimSuffix(pc.path, "/"),
 		Subpath: subpath,
 		Repo:    pc.repo,
 		Display: pc.display,


### PR DESCRIPTION
Trimming a `/` from the path `/` resulted in a broken config.

Example:
```
paths:
  /:
    repo: repo1

  /middle:
    repo: repo2
```

Using this config any subpackage in `repo1` that sorted before `middle` would work, but anything after would cause a 404 response. This can be reproduced in `TestPathConfigSetFind` by changing any paths of `"/"` in the `paths` field to `""` (which is actually what `find()` was receiving).

With this patch, `/` urls are preserved as `/` and all subpackages of `repo1` will be available from the vanity url, so `TestPathConfigSetFind` accurately reflects the behaviour of `find()`.
