### PR TITLE
Allow using `subpath` as a variable in `repo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ paths:
     </tr>
   </tbody>
 </table>
+
+### Dynamic sub-path
+You can use the placeholder `{subpath}` in your `repo` or `display` in
+order to create a dynamic subdirectory. I.E map `example.com/group/<any-project-name>` to `github.com/example/group-<any-project-name>`
+

--- a/handler.go
+++ b/handler.go
@@ -115,8 +115,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}{
 		Import:  h.Host(r) + pc.path,
 		Subpath: subpath,
-		Repo:    pc.repo,
-		Display: pc.display,
+		Repo:    strings.Replace(pc.repo, "{subpath}", subpath, -1),
+		Display: strings.Replace(pc.display, "{subpath}", subpath, -1),
 		VCS:     pc.vcs,
 	}); err != nil {
 		http.Error(w, "cannot render the page", http.StatusInternalServerError)

--- a/vanity.yaml
+++ b/vanity.yaml
@@ -6,3 +6,6 @@ paths:
 
   /launchpad:
     repo: https://github.com/rakyll/launchpad
+
+  /opencensus/:
+    repo: https://github.com/rakyll/opencensus-{subpath}


### PR DESCRIPTION
This PR allows you to use the placeholder `{subpath}` in your `repo` or `display` in
order to create a dynamic subdirectory. I.E map `example.com/group/<any-project-name>` to `github.com/example/group-<any-project-name>`
