### PR TITLE
add gitlab/github/bitbucket as cvs methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ paths:
     <tr>
       <th scope="row"><code>vcs</code></th>
       <td>required if ambiguous</td>
-      <td>If the version control system cannot be inferred (e.g. for Bitbucket or a custom domain), then this specifies the version control system as it would appear in <a href="https://golang.org/cmd/go/#hdr-Remote_import_paths"><code>go-import</code> meta tag</a>.  This can be one of <code>git</code>, <code>hg</code>, <code>svn</code>, or <code>bzr</code>.</td>
+      <td>If the version control system cannot be inferred (e.g. for Bitbucket or a custom domain), then this specifies the version control system as it would appear in <a href="https://golang.org/cmd/go/#hdr-Remote_import_paths"><code>go-import</code> meta tag</a>.  This can be one of <code>git</code>, <code>hg</code>, <code>svn</code>, or <code>bzr</code>.<br />
+      You can also use <code>gitlab</code>/<code>github</code>/<code>bitbucket</code> which will be translated to <code>git</code> and will add the default <code>disaplay</code></td>
     </tr>
   </tbody>
 </table>

--- a/handler.go
+++ b/handler.go
@@ -71,15 +71,23 @@ func newHandler(config []byte) (*handler, error) {
 		switch {
 		case e.Display != "":
 			// Already filled in.
+		case pc.vcs == "github":
+			fallthrough
+		case pc.vcs == "gitlab":
+			pc.vcs = "git"
+			fallthrough
 		case strings.HasPrefix(e.Repo, "https://github.com/"):
 			pc.display = fmt.Sprintf("%v %v/tree/master{/dir} %v/blob/master{/dir}/{file}#L{line}", e.Repo, e.Repo, e.Repo)
+		case pc.vcs == "bitbucket":
+			pc.vcs = "git"
+			fallthrough
 		case strings.HasPrefix(e.Repo, "https://bitbucket.org"):
 			pc.display = fmt.Sprintf("%v %v/src/default{/dir} %v/src/default{/dir}/{file}#{file}-{line}", e.Repo, e.Repo, e.Repo)
 		}
 		switch {
-		case e.VCS != "":
+		case pc.vcs != "":
 			// Already filled in.
-			if e.VCS != "bzr" && e.VCS != "git" && e.VCS != "hg" && e.VCS != "svn" {
+			if pc.vcs != "bzr" && pc.vcs != "git" && pc.vcs != "hg" && pc.vcs != "svn" {
 				return nil, fmt.Errorf("configuration for %v: unknown VCS %s", path, e.VCS)
 			}
 		case strings.HasPrefix(e.Repo, "https://github.com/"):


### PR DESCRIPTION
This PR allows you to specify `github` or `gitlab` or `bitbucket` in the `cvs` parameter, and that will be translated to `git` and uses the default `display` format for this platforms.

This is useful in case you are using a hosted solution