### PR TITLE
Proposal: Using GitHub actions to run tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,18 @@
+name: Run Go tests
+on:
+  push:
+    # We want to run the workflow on all branches.
+    # But you can restrict the runs if necessary.
+    branches:
+      - "*"
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2-beta
+      with:
+        # The Go version to download (if necessary) and use.
+        go-version: '^1.13.1'
+    - run: go test ./...


### PR DESCRIPTION
This PR adds the GitHub actions [go action](https://github.com/actions/setup-go) ([longer explanation of what this is](https://sosedoff.com/2019/02/12/go-github-actions.html)) and begins running tests on GitHub actions.

Both Travis CI file and actions can co-exist, and the basic feature sets are approximately the same. The major difference is that actions are based on community contributed (sometimes GitHub curated) code, so improvements are easier.

I've also proposed this change because the Travis CI product has gone through some changes in the past few months, introducing some risk.